### PR TITLE
Fix compatibility issue with haxe 4: "macro-in-macro"

### DIFF
--- a/src/autotest/IncludeTestsMacro.hx
+++ b/src/autotest/IncludeTestsMacro.hx
@@ -44,7 +44,7 @@ class IncludeTestsMacro {
 	public static function buildTests() {
 		var fields = Context.getBuildFields();
 
-		var testSuite = Compiler.getDefine('autotest_suite');
+		var testSuite = Context.definedValue('autotest_suite');
 		if (testSuite != null && StringTools.trim(testSuite) != "") {
 			return makeTestSuiteProxy(fields, testSuite);
 		}


### PR DESCRIPTION
In haxe 4, when Compiler.getDefine is called from
a macro, it throws an error (macro-in-macro),
so changed IncludeTestsMacro to use Context.definedValue.